### PR TITLE
$target을 생성하지 않는 구조로 변경

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -1,19 +1,29 @@
 import { dom } from '@/utils/babel';
 import { Test, Node } from '@/components';
 
-/** @jsx dom */
+interface State {
+  displayTest: boolean;
+}
 
-export default class App extends Node {
+/** @jsx dom */
+export default class App extends Node<unknown, State> {
   constructor() {
     super();
-    this.$target = document.createElement('div');
-    this.render();
+    this.state = {
+      displayTest: true,
+    };
+  }
+
+  onClick() {
+    this.setState({ displayTest: !this.state.displayTest });
+    console.log(this.state);
   }
 
   templete() {
     return (
       <div style={{ color: 'blue', 'background-color': 'white' }} width="12px">
-        <Test width="1px">123</Test>
+        {this.state.displayTest && <Test width="1px">Test</Test>}
+        <button onclick={this.onClick.bind(this)}>Test삭제/보이기</button>
       </div>
     );
   }

--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -2,29 +2,25 @@ import { dom } from '@/utils/babel';
 
 /** @jsx dom */
 export default class Node<Props = unknown, State = unknown> {
-  $target: HTMLElement;
+  $dom: HTMLElement;
   props?: Props & { children?: HTMLElement[] };
-  $state?: State;
+  state?: State;
 
   constructor(props?: Props & { children?: HTMLElement[] }) {
     this.props = props;
   }
 
-  get target() {
-    return this.$target;
-  }
-
   setState(newState: State) {
-    this.$state = { ...this.$state, ...newState };
-    this.render();
-  }
-
-  templete() {
-    return document.createDocumentFragment();
+    this.state = { ...this.state, ...newState };
+    this.$dom.replaceWith(this.render());
   }
 
   render() {
-    this.$target.innerHTML = '';
-    this.$target.appendChild(this.templete());
+    this.$dom = this.templete();
+    return this.$dom;
+  }
+
+  templete(): HTMLElement {
+    throw new Error('Method not implemented.');
   }
 }

--- a/src/components/Test/Test.tsx
+++ b/src/components/Test/Test.tsx
@@ -13,26 +13,24 @@ interface State {
 export default class Test extends Node<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.$state = {
+    this.state = {
       num: 1,
     };
-    this.$target = document.createElement('li');
-    this.render();
   }
 
   onClick() {
-    this.setState({ num: ++this.$state.num });
+    this.setState({ num: ++this.state.num });
   }
 
   templete() {
     const { children } = this.props;
-    const { num } = this.$state;
+    const { num } = this.state;
 
     return (
       <div>
-        <div>{children}</div>
-        <div>{num}</div>
-        <button onclick={this.onClick.bind(this)}>버튼</button>
+        <div>Component: {children}</div>
+        <div>State: {num}</div>
+        <button onclick={this.onClick.bind(this)}> Test State 증가</button>
       </div>
     );
   }

--- a/src/utils/babel.ts
+++ b/src/utils/babel.ts
@@ -3,7 +3,7 @@ export interface propsType {
 }
 
 export const dom = (
-  name: string | (new (props: propsType) => { $target: HTMLElement }),
+  name: string | (new (props: propsType) => { render: () => HTMLElement }),
   props: propsType,
   ...children: HTMLElement[]
 ) => {
@@ -12,7 +12,7 @@ export const dom = (
     name;
     const Component = new name({ ...props, children });
 
-    return Component.$target;
+    return Component.render();
   }
 
   // intrinsic Elements


### PR DESCRIPTION
컴포넌트가 반환하는 돔 구조를 작성하는 곳이 두 위치로 분류 됨에 따라 코드 가독성 및 사용 구조가 좋지 않았음.

이에 $target을 생성하지 않고 렌더링 되도록 구조를 변경하였음.

