### PR TITLE
fix: setState의 type 문제 수정

### DIFF
--- a/src/components/Node/Node.tsx
+++ b/src/components/Node/Node.tsx
@@ -10,7 +10,7 @@ export default class Node<Props = unknown, State = unknown> {
     this.props = props;
   }
 
-  setState(newState: State) {
+  setState(newState: Partial<State>) {
     this.state = { ...this.state, ...newState };
 
     const $parent = this.$node.parentElement;


### PR DESCRIPTION
- newState의 타입은 optional이 되어야 한다.
- 변경하고자 하는 property만 입력하고, 기존의 property들은 유지되는 로직을 사용하기 때문